### PR TITLE
pass correct role arn in test deploy workflow

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
-          OPENDATA_AWS_ROLE_ARN: ${{ secrets.OPENDATA_AWS_ROLE_ARN }}
+          OPENDATA_AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           OPENDATA_CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
           AWS_APPLICATION_ACCOUNT_ID: ${{ secrets.AWS_APPLICATION_ACCOUNT_ID }}
           CERTIFICATE_ARN: ${{ secrets.CERTIFICATE_ARN }}


### PR DESCRIPTION
The deployment includes two applications: a bucket and an API. The composite action deploys the bucket using the OPENDATA_AWS_ROLE_ARN and OPENDATA_CLOUDFORMATION_ROLE_ARN parameters; the api via the AWS_ROLE_ARN and CLOUDFORMATION_ROLE_ARN parameters

In test, they're both deployed to the same account, so we pass the same secrets to both sets of parameters. In production, they're deployed to different accounts, so we provide separate sets of secrets to each set of parameters.